### PR TITLE
Bump wagon-ssh-external from 3.4.3 to 3.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1624,7 +1624,7 @@
         <swagger-parser.version>2.0.26</swagger-parser.version>
         <testng.version>7.3.0</testng.version>
         <violations-maven-plugin.version>1.34</violations-maven-plugin.version>
-        <wagon-ssh-external.version>3.4.3</wagon-ssh-external.version>
+        <wagon-ssh-external.version>3.5.1</wagon-ssh-external.version>
         <wagon-svn.version>1.12</wagon-svn.version>
         <wagon-webdav.version>1.0-beta-2</wagon-webdav.version>
     </properties>


### PR DESCRIPTION
Bumps wagon-ssh-external from 3.4.3 to 3.5.1.
